### PR TITLE
Add no-enzyme-mount rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,5 +27,6 @@ module.exports = {
         'no-translation-outside-of-function': require('./rules/no-translation-outside-of-function'),
         'no-unassigned-requires': require('./rules/no-unassigned-requires'),
         'no-unhandled-promise-errors': require('./rules/no-unhandled-promise-errors'),
+        'no-enzyme-mount': require('./rules/no-enzyme-mount'),
     }
 };

--- a/lib/rules/__tests__/no-enzyme-mount/invalid.js
+++ b/lib/rules/__tests__/no-enzyme-mount/invalid.js
@@ -1,0 +1,16 @@
+jest.unmock('../Component');
+
+import React from 'react';
+import Component from '../Component';
+
+describe('<Component />', () => {
+
+    describe('with default props', () => {
+        const wrapper = enzyme.mount(<Component />);
+
+        it('should render', () => {
+            expect(wrapper.hasClass('Component')).toEqual(true);
+        });
+    });
+
+});

--- a/lib/rules/__tests__/no-enzyme-mount/valid.js
+++ b/lib/rules/__tests__/no-enzyme-mount/valid.js
@@ -1,0 +1,16 @@
+jest.unmock('../Component');
+
+import React from 'react';
+import Component from '../Component';
+
+describe('<Component />', () => {
+
+    describe('with default props', () => {
+        const wrapper = enzyme.shallow(<Component />);
+
+        it('should render', () => {
+            expect(wrapper.hasClass('Component')).toEqual(true);
+        });
+    });
+
+});

--- a/lib/rules/__tests__/no-enzyme-mount_test.js
+++ b/lib/rules/__tests__/no-enzyme-mount_test.js
@@ -1,0 +1,30 @@
+var rule = require('../no-enzyme-mount');
+var RuleTester = require('eslint').RuleTester;
+var readFileSync = require('fs').readFileSync;
+var resolve = require('path').resolve;
+var parserOptions = {
+    sourceType: "module",
+    ecmaVersion: 6,
+    ecmaFeatures: {
+        jsx: true
+    }
+};
+
+var ruleTester = new RuleTester();
+ruleTester.run('no-enzyme-mount', rule, {
+    valid: ['valid.js'].map(function(path) {
+        return {
+            parserOptions: parserOptions,
+            code: readFileSync(resolve(__dirname, './no-enzyme-mount/', path), 'utf8'),
+        };
+    }),
+    invalid: ['invalid.js'].map(function(path) {
+        return {
+            parserOptions: parserOptions,
+            code: readFileSync(resolve(__dirname, './no-enzyme-mount/', path), 'utf8'),
+            errors: [
+                { ruleId: 'no-enzyme-mount' }
+            ],
+        };
+    }),
+});

--- a/lib/rules/no-enzyme-mount.js
+++ b/lib/rules/no-enzyme-mount.js
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// Rule Definition
+//
+// This rule ensures we don't use enzyme.mount, preferring integrations tests
+// for any DOM mounted testing
+//------------------------------------------------------------------------------
+
+var MESSAGE = ' should use enzyme.shallow. If your component must be mounted, try integration tests.';
+
+module.exports = function (context) {
+    return {
+        "MemberExpression": function (node) {
+            if (node.object.type === 'Identifier' &&
+                node.object.name === 'enzyme' &&
+                node.property.type === 'Identifier' &&
+                node.property.name === 'mount') {
+                context.report(node, context.getSource(node.parent) + MESSAGE);
+            }
+        }
+    };
+};

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "eslint-plugin-pinterest",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "lib/index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --harmony lib/**/__tests__/*_test.js"
+    "test": "./node_modules/mocha/bin/mocha --harmony lib/**/__tests__/*_test.js --reporter dot"
   },
   "devDependencies": {
     "eslint": "~2.5.3",


### PR DESCRIPTION
This rule restricts use of enzyme.mount.

As our test suite grows it will be good to encourage best practices, one being to use enzyme.shallow (the faster, better mocked option) whenever possible. We should have engineers write integration tests for tests that require DOM mounting, and for the rare cases they can add explicit disabling of this rule in their test via `/* eslint pinterest/no-enzyme-mount:0 */`.