### PR TITLE
Fix no-module-factory-load rule

### DIFF
--- a/lib/rules/no-module-factory-load.js
+++ b/lib/rules/no-module-factory-load.js
@@ -17,7 +17,7 @@ module.exports = function (context) {
                 node.init.callee.type === 'Identifier' &&
                 node.init.callee.name === 'require') {
 
-                if (node.init.arguments[0].value.includes('moduleFactory.js')) {
+                if (node.init.arguments[0].value && node.init.arguments[0].value.includes('moduleFactory.js')) {
                     moduleFactoryVarName = node.id.name;
                 }
             }


### PR DESCRIPTION
In case `node.init.arguments[0].value` is undefined