### PR TITLE
No dynamic i18n calls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ module.exports = {
         'no-commented-out-tests': require('./rules/no-commented-out-tests'),
         'no-data-options-dot-notation': require('./rules/no-data-options-dot-notation'),
         'no-direct-p-pubsub-subscribe-call-in-modules': require('./rules/no-direct-p-pubsub-subscribe-call-in-modules'),
+        'no-dynamic-i18n-calls': require('./rules/no-dynamic-i18n-calls'),
         'no-duplicate-jquery-selectors': require('./rules/no-duplicate-jquery-selectors'),
         'no-module-factory-load': require('./rules/no-module-factory-load'),
         'no-goog-provide': require('./rules/no-goog-provide'),

--- a/lib/rules/__tests__/no-dynamic-i18n-calls/invalid.js
+++ b/lib/rules/__tests__/no-dynamic-i18n-calls/invalid.js
@@ -1,0 +1,4 @@
+const i18n = { _: () => {} };
+const getText = () => 'Hello world';
+i18n._(`Hello world${1}`);
+i18n._(getText());

--- a/lib/rules/__tests__/no-dynamic-i18n-calls/valid.js
+++ b/lib/rules/__tests__/no-dynamic-i18n-calls/valid.js
@@ -1,0 +1,4 @@
+const i18n = { _: () => {} };
+i18n._('Hello world');
+i18n._("Hello world");
+i18n._(`Hello world`);

--- a/lib/rules/__tests__/no-dynamic-i18n-calls_test.js
+++ b/lib/rules/__tests__/no-dynamic-i18n-calls_test.js
@@ -1,0 +1,28 @@
+var rule = require('../no-dynamic-i18n-calls');
+var RuleTester = require('eslint').RuleTester;
+var readFileSync = require('fs').readFileSync;
+var resolve = require('path').resolve;
+var parserOptions = {
+    sourceType: "module",
+    ecmaVersion: 6,
+};
+
+var ruleTester = new RuleTester();
+ruleTester.run('no-dynamic-i18n-calls', rule, {
+    valid: ['valid.js'].map(function(path) {
+        return {
+            parserOptions: parserOptions,
+            code: readFileSync(resolve(__dirname, './no-dynamic-i18n-calls/', path), 'utf8'),
+        };
+    }),
+    invalid: ['invalid.js'].map(function(path) {
+        return {
+            parserOptions: parserOptions,
+            code: readFileSync(resolve(__dirname, './no-dynamic-i18n-calls/', path), 'utf8'),
+            errors: [
+                { ruleId: 'no-dynamic-i18n-calls' },
+                { ruleId: 'no-dynamic-i18n-calls' }
+            ],
+        };
+    }),
+});

--- a/lib/rules/no-dynamic-i18n-calls.js
+++ b/lib/rules/no-dynamic-i18n-calls.js
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+// Rule Definition
+//
+// This rule ensures that only non-template strings are used in i18n._
+// These should fail: i18n._(someFunc() || `test${foo}`)
+// These should pass: i18n._('test' || "test" || `test`)
+//------------------------------------------------------------------------------
+
+function isI18n(node) {
+    return (
+        node.type === 'MemberExpression' &&
+        node.object.type === 'Identifier' &&
+        node.object.name === 'i18n' &&
+        node.property.type === 'Identifier' &&
+        node.property.name === '_'
+    );
+}
+
+function isValidArgument(arg) {
+    return arg && (
+        (arg.type === 'Literal' && typeof arg.value === 'string') ||
+        (arg.type === 'TemplateLiteral' && arg.expressions.length === 0)
+    );
+}
+
+module.exports = function (context) {
+    return {
+        "CallExpression": function (node) {
+            if (isI18n(node.callee) && !isValidArgument(node.arguments[0])) {
+                context.report(node, 'Do not use dynamic variables in i18n._()');
+            }
+        }
+    };
+};


### PR DESCRIPTION
I've seen several people using functions or other things in the i18n calls. This should help catch that earlier. I supported expressionless template strings even though we lint against them, just in case in the future we want to allow them.

**These are good**
```
i18n._('Foo');
i18n._("Foo");
i18n._(`Foo`);
```

**These are bad**
```
i18n._(`Foo${someVar}`);
i18n._(someFunc());
```