### PR TITLE
Add linting on other i18n args

### DIFF
--- a/lib/rules/__tests__/no-dynamic-i18n-calls/invalid.js
+++ b/lib/rules/__tests__/no-dynamic-i18n-calls/invalid.js
@@ -1,4 +1,17 @@
 const i18n = { _: () => {} };
+const context = 'context';
+const plural = 'plural';
 const getText = () => 'Hello world';
+
+// Interpolated template strings
 i18n._(`Hello world${1}`);
+// Function calls
 i18n._(getText());
+// Variables
+i18n._(context);
+// Context
+i18n._('Hi', context);
+i18n._('Hi', 'plural', 1, context);
+// Plural arg
+i18n._('Hi', plural, 1);
+i18n._('Hi', plural, 1, 'context');

--- a/lib/rules/__tests__/no-dynamic-i18n-calls/valid.js
+++ b/lib/rules/__tests__/no-dynamic-i18n-calls/valid.js
@@ -5,3 +5,6 @@ i18n._(`Hello world`);
 i18n._('Multiline strings' +
        'that wrap across multiple' +
        'lines');
+i18n._('Hi', 'context');
+i18n._('Hi', 'plural', 1);
+i18n._('Hi', 'plural', 1, 'context');

--- a/lib/rules/__tests__/no-dynamic-i18n-calls_test.js
+++ b/lib/rules/__tests__/no-dynamic-i18n-calls_test.js
@@ -20,8 +20,13 @@ ruleTester.run('no-dynamic-i18n-calls', rule, {
             parserOptions: parserOptions,
             code: readFileSync(resolve(__dirname, './no-dynamic-i18n-calls/', path), 'utf8'),
             errors: [
-                { ruleId: 'no-dynamic-i18n-calls' },
-                { ruleId: 'no-dynamic-i18n-calls' }
+                { ruleId: 'no-dynamic-i18n-calls', message: 'The first argument in i18n._() must be a raw string.' },
+                { ruleId: 'no-dynamic-i18n-calls', message: 'The first argument in i18n._() must be a raw string.' },
+                { ruleId: 'no-dynamic-i18n-calls', message: 'The first argument in i18n._() must be a raw string.' },
+                { ruleId: 'no-dynamic-i18n-calls', message: 'The <context> argument in i18n._() must be a raw string.' },
+                { ruleId: 'no-dynamic-i18n-calls', message: 'The <context> argument in i18n._() must be a raw string.' },
+                { ruleId: 'no-dynamic-i18n-calls', message: 'The <plural> argument in i18n._() must be a raw string.' },
+                { ruleId: 'no-dynamic-i18n-calls', message: 'The <plural> argument in i18n._() must be a raw string.' },
             ],
         };
     }),

--- a/lib/rules/no-dynamic-i18n-calls.js
+++ b/lib/rules/no-dynamic-i18n-calls.js
@@ -17,10 +17,10 @@ function isI18n(node) {
 }
 
 function isMultilineBinary(arg) {
-  return arg.operator === '+' && isValidArgument(arg.left) && isValidArgument(arg.right);
+  return arg.operator === '+' && isString(arg.left) && isString(arg.right);
 }
 
-function isValidArgument(arg) {
+function isString(arg) {
     return arg && (
         (arg.type === 'Literal' && typeof arg.value === 'string') ||
         (arg.type === 'TemplateLiteral' && arg.expressions.length === 0) ||
@@ -28,11 +28,31 @@ function isValidArgument(arg) {
     );
 }
 
+function validateArgs(args) {
+  const len = args.length;
+  if (!isString(args[0])) {
+    return 'The first argument in i18n._() must be a raw string.';
+  }
+  if (len === 2 && !isString(args[1])) {
+    return 'The <context> argument in i18n._() must be a raw string.';
+  }
+  if ((len === 3 || len === 4) && !isString(args[1])) {
+    return 'The <plural> argument in i18n._() must be a raw string.';
+  }
+  if (len === 4 && !isString(args[3])) {
+    return 'The <context> argument in i18n._() must be a raw string.';
+  }
+  return null;
+}
+
 module.exports = function (context) {
     return {
         "CallExpression": function (node) {
-            if (isI18n(node.callee) && !isValidArgument(node.arguments[0])) {
-                context.report(node, 'Do not use dynamic variables in i18n._()');
+            if (isI18n(node.callee)) {
+              const error = validateArgs(node.arguments);
+              if (error) {
+                context.report(node, error);
+              }
             }
         }
     };


### PR DESCRIPTION
Caught a PR where somebody was using a variable for the context in the string. This is also not supported for string extraction, so this PR adds support for linting against non-literal string arguments for the plural and context args.