### PR TITLE
no-relative-paths fixes

### DIFF
--- a/lib/rules/no-relative-paths.js
+++ b/lib/rules/no-relative-paths.js
@@ -31,7 +31,8 @@ function isRelativePath(path) {
 function generateRootPath(filePath) {
     return function(relPath) {
         var absPath = path.resolve(path.dirname(filePath), relPath);
-        return JSON.stringify(absPath.match(/webapp\/(.*)/)[1]);
+        var match = absPath.match(/pinboard\/webapp\/(.*)/);
+        return match && match.length > 1 && JSON.stringify(match[1]);
     }
 }
 
@@ -67,9 +68,10 @@ module.exports = {
                         node: node,
                         message: message + context.getSource(node)
                     };
-                    if (isAutofixable) {
+                    var fixedPath = generateFixedPath(node.source.value);
+                    if (isAutofixable && fixedPath) {
                         report['fix'] = function(fixer) {
-                            return fixer.replaceText(node.source, generateFixedPath(node.source.value));
+                            return fixer.replaceText(node.source, fixedPath);
                         }
                     }
                     context.report(report);
@@ -86,9 +88,10 @@ module.exports = {
                                 node: node,
                                 message: message + context.getSource(node)
                             };
-                            if (isAutofixable) {
+                            var fixedPath = generateFixedPath(requirePath);
+                            if (isAutofixable && fixedPath) {
                                 report['fix'] = function(fixer) {
-                                    return fixer.replaceText(node.arguments[0], generateFixedPath(requirePath));
+                                    return fixer.replaceText(node.arguments[0], fixedPath);
                                 }
                             }
                             context.report(report);
@@ -107,9 +110,10 @@ module.exports = {
                                     node: node,
                                     message: message + context.getSource(node.parent)
                                 };
-                                if (isAutofixable) {
+                                var fixedPath = generateFixedPath(usedPath);
+                                if (isAutofixable && fixedPath) {
                                     report['fix'] = function(fixer) {
-                                        return fixer.replaceText(node.parent.arguments[0], generateFixedPath(usedPath));
+                                        return fixer.replaceText(node.parent.arguments[0], fixedPath);
                                     }
                                 }
                                 context.report(report);

--- a/lib/rules/no-relative-paths.js
+++ b/lib/rules/no-relative-paths.js
@@ -75,13 +75,12 @@ module.exports = {
                     context.report(report);
                 });
             },
-            VariableDeclarator: function(node) {
-                if (node.init && node.init.type === 'CallExpression' &&
-                    node.init.callee.type === 'Identifier' &&
-                    node.init.callee.name === 'require') {
+            CallExpression: function(node) {
+                if (node.callee.type === 'Identifier' &&
+                    node.callee.name === 'require') {
 
-                    if (node.init.arguments && node.init.arguments.length === 1) {
-                        var requirePath = node.init.arguments[0].value;
+                    if (node.arguments && node.arguments.length === 1) {
+                        var requirePath = node.arguments[0].value;
                         checkPath(requirePath, function(isAutofixable) {
                             var report = {
                                 node: node,
@@ -89,7 +88,7 @@ module.exports = {
                             };
                             if (isAutofixable) {
                                 report['fix'] = function(fixer) {
-                                    return fixer.replaceText(node.init.arguments[0], generateFixedPath(requirePath));
+                                    return fixer.replaceText(node.arguments[0], generateFixedPath(requirePath));
                                 }
                             }
                             context.report(report);


### PR DESCRIPTION
- Fixes issue where `require()` statements with assignment are missed
- Fixes issue with autofixer where relative paths that reach outside of webapp/ are incorrectly fixed