### PR TITLE
Add the only-safe-imports linter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,7 @@ module.exports = {
         'no-unassigned-requires': require('./rules/no-unassigned-requires'),
         'no-unhandled-promise-errors': require('./rules/no-unhandled-promise-errors'),
         'no-enzyme-mount': require('./rules/no-enzyme-mount'),
+        'only-safe-imports': require('./rules/only-safe-imports'),
         'sort-imports': require('./rules/sort-imports'),
     }
 };

--- a/lib/rules/only-safe-imports.js
+++ b/lib/rules/only-safe-imports.js
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Rule to only allow imports from certain paths
+ * @author Arthur Lee <arthur@pinterest.com>
+ */
+
+var path = require('path');
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+function isWebpackMagicPath(path) {
+    return path.indexOf('!') !== -1;
+}
+
+function normalizeWebpackPath(path) {
+    var pathComponents = path.split('!');
+    if (pathComponents.length === 1) {
+        return pathComponents[0];
+    } else {
+        return pathComponents[pathComponents.length - 1];
+    }
+}
+
+// "root path" refers to paths relative to webapp/
+function rootPathFromAbs(path) {
+    var match = path.match(/pinboard\/webapp\/(.*)/);
+    return match && match.length > 1 && match[1];
+}
+
+function rootPathFromRel(relPath, root) {
+    var absPath = path.resolve(root, relPath);
+    return rootPathFromAbs(absPath);
+}
+
+function normalizePath(path, root) {
+    if (isWebpackMagicPath(path)) {
+        path = normalizeWebpackPath(path);
+    }
+    if (isRelativePath(path)) {
+        path = rootPathFromRel(path, root);
+    }
+    
+    return path;
+}
+
+function isRelativePath(path) {
+    return path.startsWith('.');
+}
+
+function isAliasedPath(aliases, importPath) {
+    for (var i=0; i < aliases.length; i++) {
+        if (importPath.startsWith(aliases[i] + '/')) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Return true if one of "rules" is fulfilled
+function checkRules(rules, aliases, selfPath, importPath) {
+    // Not an aliased path, which means we are importing a node module
+    if (aliases !== null && !isAliasedPath(aliases, importPath)) {
+        return true;
+    }
+    
+    for (var i=0; i < rules.length; i++) {
+        var fromRegex = new RegExp(rules[i].from);
+        var toRegex = new RegExp(rules[i].to);
+        
+        // check if rule applies to me
+        if (fromRegex.test(selfPath) && toRegex.test(importPath)) {
+            return true;
+        }
+    }
+    return false;
+};
+
+function getChecker(context) {
+    var options = (context.options && context.options[0]) || {};
+    var aliases = options['aliases'];
+    var whitelist = options['whitelisted-imports'] || [];
+    var blacklist = options['blacklisted-imports'] || [];
+    var selfPath = rootPathFromAbs(context.getFilename());
+
+    return function(inputPath, callback) {
+        if (!inputPath) return;
+        
+        var importPath = normalizePath(inputPath, path.dirname(context.getFilename()));
+        
+        // look for at least one rule fulfilled from the whitelist
+        // make sure no rules are broken from the blacklist
+        if (!checkRules(whitelist, aliases, selfPath, importPath) ||
+            checkRules(blacklist, null, selfPath, importPath)) {
+            callback('Import disallowed by rules: ' + inputPath);
+        }
+    };
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow require/imports that are not whitelisted",
+            category: "ECMAScript 6",
+            recommended: false
+        }
+    },
+
+    create: function(context) {
+        var checkPath = getChecker(context);
+        return {
+            ImportDeclaration: function(node) {
+                checkPath(node.source.value, function(message) {
+                    context.report({
+                        node: node,
+                        message: message
+                    });
+                });
+            },
+            CallExpression: function(node) {
+                if (node.callee.type === 'Identifier' &&
+                    node.callee.name === 'require') {
+
+                    if (node.arguments && node.arguments.length === 1) {
+                        var requirePath = node.arguments[0].value;
+                        checkPath(requirePath, function(message) {
+                            context.report({
+                                node: node,
+                                message: message
+                            });
+                        });
+                    }
+                }
+            }
+        };
+    }
+};


### PR DESCRIPTION
The only-safe-import linter takes two options - an array of aliases (that are set up in webpack, so that requires of npm packages are ignored) and a map of rules.

Rules contain a whitelist of imports that are allowed.

Rules are regex:regex mappings, where the key refers to a regex that matches the source file path and the value is a regex that matches the import path.

Sample .eslintrc.json usage:
```
{
    "rules": {
        "pinterest/only-safe-imports" : [2,
            ["app", "node", "locale", "const", "build"],
            {
                "^app/": "^app/common/|^build/|^const/|^node/",
                "^app/analytics/": "^app/analytics/",
                "^app/eval/": "^app/eval/",
                "^app/internal/": "^app/internal/",
                "^app/sterling/": "^app/sterling/"
            }
        ]
}
```