### PR TITLE
Add no-i18n-without-context rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ module.exports = {
         'no-module-factory-load': require('./rules/no-module-factory-load'),
         'no-goog-provide': require('./rules/no-goog-provide'),
         'no-goog-require': require('./rules/no-goog-require'),
+        'no-i18n-without-context': require('./rules/no-i18n-without-context'),
         'no-invalid-binds': require('./rules/no-invalid-binds'),
         'no-jquery-outside-of-render': require('./rules/no-jquery-outside-of-render'),
         'no-jquery-var-without-$': require('./rules/no-jquery-var-without-$'),

--- a/lib/rules/no-dynamic-i18n-calls.js
+++ b/lib/rules/no-dynamic-i18n-calls.js
@@ -6,15 +6,7 @@
 // These should pass: i18n._('test' || "test" || `test`)
 //------------------------------------------------------------------------------
 
-function isI18n(node) {
-    return (
-        node.type === 'MemberExpression' &&
-        node.object.type === 'Identifier' &&
-        node.object.name === 'i18n' &&
-        node.property.type === 'Identifier' &&
-        node.property.name === '_'
-    );
-}
+const isI18n = require('../utils').isI18n;
 
 function isMultilineBinary(arg) {
   return arg.operator === '+' && isString(arg.left) && isString(arg.right);

--- a/lib/rules/no-i18n-without-context.js
+++ b/lib/rules/no-i18n-without-context.js
@@ -1,0 +1,20 @@
+//------------------------------------------------------------------------------
+// Rule Definition
+//
+// This rule ensures we don't define i18n strings without context
+// This should fail: i18n._('test'')
+// This should pass: i18n._('test', 'my super awesome test string context')
+//------------------------------------------------------------------------------
+
+const isI18n = require('../utils').isI18n;
+
+module.exports = function(context) {
+    return {
+        CallExpression: function (node) {
+            if (!isI18n(node.callee) || node.arguments.length >= 2) {
+              return;
+            }
+            context.report(node, 'Context should be provided for i18n strings');
+        },
+    };
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,12 @@
+
+module.exports = {
+  isI18n(node) {
+    return (
+        node.type === 'MemberExpression' &&
+        node.object.type === 'Identifier' &&
+        node.object.name === 'i18n' &&
+        node.property.type === 'Identifier' &&
+        node.property.name === '_'
+    );
+  }
+}


### PR DESCRIPTION
This adds a rule to lint against use of `i18n._()` without providing context.

Context is currently marked as optional, but we should really be reminding developers to provide context as much as possible.  LMK if this looks good and I'll add a test 😄 
